### PR TITLE
refactor(SanitizationException): Replace instance-based exception wit…

### DIFF
--- a/src/Exception/SanitizationException.php
+++ b/src/Exception/SanitizationException.php
@@ -4,6 +4,23 @@ declare(strict_types=1);
 
 namespace KaririCode\Sanitizer\Exception;
 
-final class SanitizationException extends \RuntimeException
+use KaririCode\Exception\AbstractException;
+
+final class SanitizationException extends AbstractException
 {
+    private const CODE_INVALID_INPUT = 4001;
+
+    public static function invalidInput(string $expectedType): self
+    {
+        $message = sprintf(
+            'Input must be a %s',
+            $expectedType
+        );
+
+        return self::createException(
+            self::CODE_INVALID_INPUT,
+            'INVALID_INPUT',
+            $message
+        );
+    }
 }

--- a/src/Processor/AbstractSanitizerProcessor.php
+++ b/src/Processor/AbstractSanitizerProcessor.php
@@ -12,7 +12,7 @@ abstract class AbstractSanitizerProcessor implements Processor
     protected function guardAgainstNonString(mixed $input): string
     {
         if (!is_string($input)) {
-            throw new SanitizationException('Input must be a string');
+            throw SanitizationException::invalidInput('string');
         }
 
         return $input;


### PR DESCRIPTION
…h static method invalidInput()

- Added static method `invalidInput()` to handle invalid input exceptions without requiring instantiation
- Utilizes `CODE_INVALID_INPUT` for consistent error code management
- Streamlines exception handling by enabling direct static calls

This refactor simplifies exception creation and enforces consistent error handling.