### PR TITLE
test(exceptions): remove #[CoversClass] from exception test to fix PH…

### DIFF
--- a/tests/Unit/Exception/SanitizationExceptionsTest.php
+++ b/tests/Unit/Exception/SanitizationExceptionsTest.php
@@ -6,12 +6,14 @@ namespace KaririCode\Sanitizer\Tests\Unit\Exception;
 
 use KaririCode\Sanitizer\Exception\InvalidRuleException;
 use KaririCode\Sanitizer\Exception\SanitizationException;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(InvalidRuleException::class)]
-#[CoversClass(SanitizationException::class)]
+// NOTE: #[CoversClass] is intentionally omitted for exception classes.
+// In PHPUnit 12 + pcov, classes that directly extend \RuntimeException
+// (a native PHP class) are reported as "not a valid target for code coverage",
+// which triggers PHPUnit warnings that — with failOnWarning="true" — exit as code 1.
+// Coverage for these classes is achieved transitively via SanitizerEngineTest and others.
 final class SanitizationExceptionsTest extends TestCase
 {
     #[Test]


### PR DESCRIPTION
…PUnit 12 CI warning

In PHPUnit 12 + pcov, classes that directly extend a native PHP class (\RuntimeException) are reported as 'not a valid target for code coverage'.

This generates 4 PHPUnit warnings — one per test method — which with the devkit-generated failOnWarning="true" in phpunit.xml.dist cause exit code 1, blocking the CI pipeline despite 100% coverage and 175 passing tests.

Fix: remove #[CoversClass(InvalidRuleException::class)] and #[CoversClass(SanitizationException::class)] from SanitizationExceptionsTest. Coverage for both exception classes is still achieved transitively via SanitizerEngineTest, InMemoryRuleRegistryTest, and integration tests.